### PR TITLE
Add tiller namespace in global node property in jenkins config 

### DIFF
--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -138,8 +138,8 @@ data:
               <default>
                 <comparator class="hudson.util.CaseInsensitiveComparator"/>
               </default>
-              <int>1</int>
-{{- range $ekey, $eval := .Values.Global.EnvVars }}
+              <int>{{ .Values.Servers.Global.NumEnvVars }}</int>
+{{- range $ekey, $eval := .Values.Servers.Global.EnvVars }}
               <string>{{ $ekey }}</string>
               <string>{{ $eval }}</string>
 {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -82,11 +82,6 @@ Master:
     # Plugins: true
     # Config: true
 
-# global node properties
-Global:
-  EnvVars:
-    DOCKER_REGISTRY: ""
-
 Agent:
   Enabled: true
   ContainerCap: 10
@@ -157,6 +152,14 @@ Servers:
   #- Name: myname
   #  Url: https://something.com/
   #  Credential: some-cred-name
+
+  # global node properties
+  Global:
+    NumEnvVars: 2
+    EnvVars:
+      DOCKER_REGISTRY: ""
+      TILLER_NAMESPACE: ""
+
 
 Persistence:
   Enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
he tiller namespace specified in the jx install command doesn't reach to the PODs. The PODs still use the tiller in kube-system namespace. PR: https://github.com/jenkins-x/jenkins-x-platform/compare/master...akihikokuroda:tillernamespace?expand=1 exposes the tiller namespace in the extraValues.yaml This change adds the TILLER_NAMESPACE environment variable in the jenkins global node configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
