### PR TITLE
Add in option to have premade Jenkins jobs

### DIFF
--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -275,6 +275,12 @@ data:
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
 {{- end }}
+{{- if .Values.Master.Jobs }}
+    for job in $(ls /var/jenkins_jobs); do
+      mkdir -p /var/jenkins_home/jobs/$job
+      cp -n /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+    done
+{{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}
   init{{ $key }}.groovy: |-
 {{ $val | indent 4 }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -145,6 +145,11 @@ spec:
         emptyDir: {}
       - name: secrets-dir
         emptyDir: {}
+      {{- if .Values.Master.Jobs }}
+      - name: jenkins-jobs
+        configMap:
+          name: {{ template "jenkins.fullname" . }}-jobs
+      {{- end }}
       - name: jenkins-home
       {{- if .Values.Persistence.Enabled }}
         persistentVolumeClaim:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -51,6 +51,12 @@ spec:
 {{ toYaml .Values.Master.InitContainerEnv | indent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.Master.Jobs }}
+            -
+              mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
             -
               mountPath: /var/jenkins_home
               name: jenkins-home

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -122,6 +122,12 @@ spec:
 {{- if .Values.Persistence.mounts }}
 {{ toYaml .Values.Persistence.mounts | indent 12 }}
 {{- end }}
+            {{- if .Values.Master.Jobs }}
+            -
+              mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
             -
               mountPath: /var/jenkins_home
               name: jenkins-home

--- a/stable/jenkins/templates/jobs.yaml
+++ b/stable/jenkins/templates/jobs.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.Master.Jobs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-jobs
+data:
+{{ toYaml .Values.Master.Jobs | indent 2 }}
+{{- end -}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -63,6 +63,10 @@ Master:
   InitScripts:
 #  - |
 #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
+  # Jenkins XML job configs to provision
+  # Jobs: |-
+  #   test: |-
+  #     <<xml here>>
   CustomConfigMap: false
 # Node labels and tolerations for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -134,7 +138,7 @@ Agent:
       #   mountPath: /var/myapp/mysecret
       NodeSelector: {}
 
-Servers:  
+Servers:
   Gitea:
   #- Name: myname
   #  Url: https://something.com/


### PR DESCRIPTION
~Still need to test, but adding a PR for review.~

Adding in ability to specify and job XML in the myvalue.yaml when running a jx install or upgrade.

Master plan is to add a pre-configured job that allows you to give git url, and build pack, and it will import the job for you into the jenkins instances you are running the job in. 