### PR TITLE
Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Session.vim
 
 # Chart dependencies
 **/charts/*.tgz
+stable/*/*.tgz
+incubator/*/*.tgz

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.9
+version: 0.10.10
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.6
+version: 0.10.7
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.4
+version: 0.10.6
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.10
+version: 0.10.11
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.9.1
+version: 0.10.4
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.22
+version: 0.10.23
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.24
+version: 0.10.25
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.26
+version: 0.10.27
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.25
+version: 0.10.26
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.21
+version: 0.10.22
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.7
+version: 0.10.9
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.14
+version: 0.10.15
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.23
+version: 0.10.24
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.27
+version: 0.10.28
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.17
+version: 0.10.18
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.16
+version: 0.10.17
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.15
+version: 0.10.16
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.19
+version: 0.10.20
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.28
+version: 0.10.29
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.18
+version: 0.10.19
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.12
+version: 0.10.14
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.29
+version: 0.10.30
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.11
+version: 0.10.12
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.20
+version: 0.10.21
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -1,0 +1,47 @@
+CHART_REPO := http://chartmuseum.thunder.35.189.66.194.nip.io
+NAME := jenkins
+OS := $(shell uname)
+RELEASE_VERSION := $(shell semver-release-version)
+
+setup:
+	minikube addons enable ingress
+	brew install kubernetes-helm
+	helm init
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+	watch kubectl get pods
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+	watch kubectl get pods
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+else ifeq ($(OS),Linux)
+	echo "linux"
+else
+	exit -1
+endif
+	# git add Chart.yaml
+	# git commit -a -m "release $(RELEASE_VERSION)"
+	# git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	# git push origin v$(RELEASE_VERSION)
+	helm package .
+	curl --data-binary "@$(NAME)-$(RELEASE_VERSION).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -1,7 +1,7 @@
-CHART_REPO := http://chartmuseum.thunder.35.189.66.194.nip.io
+CHART_REPO := http://chartmuseum.thunder.thunder.fabric8.io
 NAME := jenkins
 OS := $(shell uname)
-RELEASE_VERSION := $(shell semver-release-version)
+RELEASE_VERSION := $(shell jx-release-version)
 
 setup:
 	minikube addons enable ingress
@@ -15,11 +15,9 @@ build: clean
 
 install: clean build
 	helm install . --name ${NAME}
-	watch kubectl get pods
 
 upgrade: clean build
 	helm upgrade ${NAME} .
-	watch kubectl get pods
 
 delete:
 	helm delete --purge ${NAME}

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -1,4 +1,4 @@
-CHART_REPO := http://chartmuseum.thunder.thunder.fabric8.io
+CHART_REPO := http://chartmuseum.build.cd.jenkins-x.io
 NAME := jenkins
 OS := $(shell uname)
 RELEASE_VERSION := $(shell jx-release-version)

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -41,5 +41,5 @@ endif
 	# git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
 	# git push origin v$(RELEASE_VERSION)
 	helm package .
-	curl --data-binary "@$(NAME)-$(RELEASE_VERSION).tgz" $(CHART_REPO)/api/charts
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(RELEASE_VERSION).tgz" $(CHART_REPO)/api/charts
 	rm -rf ${NAME}*.tgz%

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -1,4 +1,4 @@
-CHART_REPO := http://chartmuseum.build.cd.jenkins-x.io
+CHART_REPO := https://chartmuseum.build.cd.jenkins-x.io
 NAME := jenkins
 OS := $(shell uname)
 RELEASE_VERSION := $(shell jx-release-version)

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -1,7 +1,7 @@
-CHART_REPO := https://chartmuseum.build.cd.jenkins-x.io
+CHART_REPO := https://chartmuseum.jx.cd.jenkins-x.io
 NAME := jenkins
 OS := $(shell uname)
-RELEASE_VERSION := $(shell jx-release-version)
+RELEASE_VERSION := 0.10.30
 
 setup:
 	minikube addons enable ingress

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -34,6 +34,11 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
 | `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
 | `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
+| `Master.AuthorizationStrategyClass`              | AuthorizationStrategy class                   | `hudson.security.FullControlOnceLoggedInAuthorizationStrategy`                                                                       |
+| `Master.AuthorizationStrategyAttributes`              | List of authorization strategy attributes                   | `denyAnonymousReadAccess: true`                                                                       |
+| `Master.SecurityRealmClass`              | SecurityRealmClass class                   | `hudson.security.LegacySecurityRealm`                                                                       |
+| `Master.SecurityRealmAttributes`              | List of security realm attributes                   | `{}`                                                                       |
+| `Master.ServiceAccountAnnotations`              | Annotations to add to the service account                  | `{}`                                                                       |
 | `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 | `Master.Cpu`                      | Master requested cpu                 | `200m`                                                                       |
 | `Master.Memory`                   | Master requested memory              | `256Mi`                                                                      |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -34,6 +34,8 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
 | `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
 | `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
+| `Master.SecurityRealm`            | Custom Security Realm                | Not set                                                                      |
+| `Master.ServiceLabels`            | Custom Service labels                | Not set                                                                      |
 | `Master.AuthorizationStrategyClass`              | AuthorizationStrategy class                   | `hudson.security.FullControlOnceLoggedInAuthorizationStrategy`                                                                       |
 | `Master.AuthorizationStrategyAttributes`              | List of authorization strategy attributes                   | `denyAnonymousReadAccess: true`                                                                       |
 | `Master.SecurityRealmClass`              | SecurityRealmClass class                   | `hudson.security.LegacySecurityRealm`                                                                       |
@@ -53,6 +55,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
+| `Master.AdditionalConfig`          | Add additional config files         | `{}`                                                                         |
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
@@ -111,6 +114,43 @@ For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
 the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
 
     kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+
+## Adding customized securityRealm
+
+ `Master.SecurityRealm` in values can be used to support custom security realm instead of default `LegacySecurityRealm`. For example, you can add a security realm to authenticate via keycloak.
+
+ ```yaml
+SecurityRealm: |-
+  <securityRealm class="org.jenkinsci.plugins.oic.OicSecurityRealm" plugin="oic-auth@1.0">
+    <clientId>testId</clientId>
+    <clientSecret>testsecret</clientSecret>
+    <tokenServerUrl>https:testurl</tokenServerUrl>
+    <authorizationServerUrl>https:testAuthUrl</authorizationServerUrl>
+    <userNameField>email</userNameField>
+    <scopes>openid email</scopes>
+  </securityRealm>
+```
+
+ ## Adding additional configs
+
+ `Master.AdditionalConfig` can be used to add additional config files in `config.yaml`. For example, it can be used to add additional config files for keycloak authentication.
+
+ ```yaml
+AdditionalConfig:
+  testConfig.txt: |-
+    - name: testName
+      clientKey: testKey
+      clientURL: testUrl
+```
+
+ ## Adding customized labels
+
+ `Master.ServiceLabels` can be used to add custom labels in `jenkins-master-svc.yaml`. For example,
+
+ ```yaml
+ServiceLabels:
+  expose: true
+```
 
 ## Persistence
 

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -12,5 +12,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "jenkins.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -99,7 +99,7 @@ data:
           <namespace>{{ .Release.Namespace }}</namespace>
           <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
           <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent:50000</jenkinsTunnel>
-          <containerCap>10</containerCap>
+          <containerCap>{{ .Values.Agent.ContainerCap }}</containerCap>
           <retentionTimeout>5</retentionTimeout>
           <connectTimeout>0</connectTimeout>
           <readTimeout>0</readTimeout>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -141,6 +141,12 @@ data:
     </scriptApproval>
 {{- end }}
   apply_config.sh: |-
+{{- if .Values.Master.Overwrite.Config }}
+    rm -rf /var/jenkins_home/config.xml
+{{- end }}
+{{- if .Values.Master.Overwrite.Plugins }}
+    rm -rf /var/jenkins_home/plugins
+{{- end }}
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -167,6 +167,7 @@ data:
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+    cp -n /var/jenkins_config/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml /var/jenkins_home;
 {{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -34,6 +34,9 @@ data:
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <inheritFrom></inheritFrom>
               <name>{{ $pval.Name }}</name>
+{{- if $pval.ServiceAccount }}
+              <serviceAccount>{{ $pval.ServiceAccount }}</serviceAccount>
+{{- end }}
               <instanceCap>2147483647</instanceCap>
               <idleMinutes>0</idleMinutes>
               <label>{{ $pval.Label }}</label>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -30,21 +30,22 @@ data:
           <name>kubernetes</name>
           <templates>
 {{- if .Values.Agent.Enabled }}
+{{- range $pkey, $pval := .Values.Agent.PodTemplates }}
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <inheritFrom></inheritFrom>
-              <name>default</name>
+              <name>{{ $pval.Name }}</name>
               <instanceCap>2147483647</instanceCap>
               <idleMinutes>0</idleMinutes>
-              <label>{{ .Release.Name }}-{{ .Values.Agent.Component }}</label>
+              <label>{{ $pval.Label }}</label>
               <nodeSelector>
                 {{- $local := dict "first" true }}
-                {{- range $key, $value := .Values.Agent.NodeSelector }}
+                {{- range $key, $value := $pval.NodeSelector }}
                   {{- if not $local.first }},{{- end }}
                   {{- $key }}={{ $value }}
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
               <volumes>
-{{- range $index, $volume := .Values.Agent.volumes }}
+{{- range $index, $volume := $pval.volumes }}
                 <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
 {{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
                   <{{ $key }}>{{ $value }}</{{ $key }}>
@@ -53,36 +54,44 @@ data:
 {{- end }}
               </volumes>
               <containers>
+{{- range $ckey, $cval := $pval.Containers }}         
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
-                  <name>jnlp</name>
-                  <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
-{{- if .Values.Agent.Privileged }}
-                  <privileged>true</privileged>
-{{- else }}
-                  <privileged>false</privileged>
-{{- end }}
-                  <alwaysPullImage>{{ .Values.Agent.AlwaysPullImage }}</alwaysPullImage>
+                  <name>{{ $ckey | lower }}</name>
+                  <image>{{ $cval.Image }}</image>
+                  <privileged>{{ default false $cval.Privileged }}</privileged>
+                  <alwaysPullImage>{{ $cval.AlwaysPullImage }}</alwaysPullImage>
                   <workingDir>/home/jenkins</workingDir>
-                  <command></command>
-                  <args>${computer.jnlpmac} ${computer.name}</args>
-                  <ttyEnabled>false</ttyEnabled>
-                  <resourceRequestCpu>{{.Values.Agent.Cpu}}</resourceRequestCpu>
-                  <resourceRequestMemory>{{.Values.Agent.Memory}}</resourceRequestMemory>
-                  <resourceLimitCpu>{{.Values.Agent.Cpu}}</resourceLimitCpu>
-                  <resourceLimitMemory>{{.Values.Agent.Memory}}</resourceLimitMemory>
-                  <envVars>
-                    <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
-                      <key>JENKINS_URL</key>
-                      <value>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
-                    </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
-                  </envVars>
+                  <command>{{ $cval.Command }}</command>
+                  <args>{{ $cval.Args }}</args>
+                  <ttyEnabled>{{ default false $cval.Tty }}</ttyEnabled>
+                  <resourceRequestCpu>{{ $cval.RequestCpu }}</resourceRequestCpu>
+                  <resourceRequestMemory>{{ $cval.RequestMemory }}</resourceRequestMemory>
+                  <resourceLimitCpu>{{ $cval.LimitCpu }}</resourceLimitCpu>
+                  <resourceLimitMemory>{{ $cval.LimitMemory }}</resourceLimitMemory>
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+{{- end }}
               </containers>
-              <envVars/>
+              <envVars>
+{{- range $ekey, $eval := $pval.EnvVars }}
+                <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+                  <key>{{ $ekey }}</key>
+                  <value>{{ $eval }}</value>
+                </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+{{- end }}
+              </envVars>
               <annotations/>
+{{- if $pval.ImagePullSecret }}
+              <imagePullSecrets>
+                <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+                  <name>{{ $pval.ImagePullSecret }}</name>
+                </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+              </imagePullSecrets>
+{{- else }}
               <imagePullSecrets/>
+{{- end }}
               <nodeProperties/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+{{- end }}
 {{- end -}}
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -135,11 +135,6 @@ data:
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
-{{- if .Values.Master.InstallPlugins }}
-    cp /var/jenkins_config/plugins.txt /var/jenkins_home;
-    rm /usr/share/jenkins/ref/plugins/*.lock
-    /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
-{{- end }}
 {{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -126,6 +126,20 @@ data:
       <globalNodeProperties/>
       <noUsageStatistics>true</noUsageStatistics>
     </hudson>
+  org.jenkinsci.plugin.gitea.servers.GiteaServers.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <org.jenkinsci.plugin.gitea.servers.GiteaServers plugin="gitea@1.0.5">
+      <servers>
+{{- range $pkey, $pval := .Values.Servers.Gitea }}
+        <org.jenkinsci.plugin.gitea.servers.GiteaServer>
+          <displayName>{{ $pval.Name }}</displayName>
+          <serverUrl>{{ $pval.Url }}</serverUrl>
+          <manageHooks>true</manageHooks>
+          <credentialsId>{{ $pval.Credential }}</credentialsId>
+        </org.jenkinsci.plugin.gitea.servers.GiteaServer>
+{{- end }}
+      </servers>
+    </org.jenkinsci.plugin.gitea.servers.GiteaServers>
 {{- if .Values.Master.ScriptApproval }}
   scriptapproval.xml: |-
     <?xml version='1.0' encoding='UTF-8'?>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -104,7 +104,7 @@ data:
 {{- end }}
 {{- end -}}
           </templates>
-          <serverUrl>{{ $agent.KubernetesServerURL | default "https://kubernetes.default" }} </serverUrl>
+          <serverUrl>{{ $agent.KubernetesServerURL | default "https://kubernetes.default" }}</serverUrl>
           <skipTlsVerify>false</skipTlsVerify>
           <namespace>{{ .Release.Namespace }}</namespace>
           <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -49,7 +49,7 @@ data:
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
               <volumes>
-{{- if $agent.DockerSocket }}
+{{- if $agent.DockerHostPath }}
                 <org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume>
                   <hostPath>{{ $agent.DockerHostPath }}</hostPath>
                   <mountPath>{{ $agent.DockerMountPath }}</mountPath>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -138,8 +138,8 @@ data:
               <default>
                 <comparator class="hudson.util.CaseInsensitiveComparator"/>
               </default>
-              <int>1</int>
-{{- range $ekey, $eval := .Values.Global.EnvVars }}
+              <int>{{ .Values.Servers.Global.NumEnvVars }}</int>
+{{- range $ekey, $eval := .Values.Servers.Global.EnvVars }}
               <string>{{ $ekey }}</string>
               <string>{{ $eval }}</string>
 {{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -70,7 +70,7 @@ data:
 {{- end }}
               </volumes>
               <containers>
-{{- range $ckey, $cval := $pval.Containers }}         
+{{- range $ckey, $cval := $pval.Containers }}
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
                   <name>{{ $ckey | lower }}</name>
                   <image>{{ $cval.Image }}</image>
@@ -95,7 +95,18 @@ data:
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
 {{- end }}
               </envVars>
+{{- if $pval.annotations }}
+              <annotations>
+  {{- range $Akey, $Avalue := $pval.annotations }}
+                <org.csanchez.jenkins.plugins.kubernetes.PodAnnotation>
+                  <key>{{ $Akey }}</key>
+                  <value>{{ $Avalue }}</value>
+                </org.csanchez.jenkins.plugins.kubernetes.PodAnnotation>
+  {{- end }}
+              </annotations>
+{{- else }}
               <annotations/>
+{{- end }}
 {{- if $pval.ImagePullSecret }}
               <imagePullSecrets>
                 <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -104,7 +104,7 @@ data:
 {{- end }}
 {{- end -}}
           </templates>
-          <serverUrl>https://kubernetes.default</serverUrl>
+          <serverUrl>{{ $agent.KubernetesServerURL | default "https://kubernetes.default" }} </serverUrl>
           <skipTlsVerify>false</skipTlsVerify>
           <namespace>{{ .Release.Namespace }}</namespace>
           <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -138,6 +138,27 @@ data:
 {{- end }}
       </endpoints>
     </org.jenkinsci.plugins.github__branch__source.GitHubConfiguration>
+  com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig plugin="gitlab-plugin@1.5.5">
+      <useAuthenticatedEndpoint>true</useAuthenticatedEndpoint>
+      <connections>
+{{- range $pkey, $pval := .Values.Servers.GitLab }}
+        <com.dabsquared.gitlabjenkins.connection.GitLabConnection>
+          <name>{{ $pval.Name }}</name>
+          <url>{{ $pval.Url }}</url>
+          <apiTokenId>{{ $pval.Credential }}</apiTokenId>
+          <clientBuilder class="com.dabsquared.gitlabjenkins.gitlab.api.impl.AutodetectGitLabClientBuilder">
+            <id>autodetect</id>
+            <ordinal>0</ordinal>
+          </clientBuilder>
+          <ignoreCertificateErrors>false</ignoreCertificateErrors>
+          <connectionTimeout>10</connectionTimeout>
+          <readTimeout>10</readTimeout>
+        </com.dabsquared.gitlabjenkins.connection.GitLabConnection>
+{{- end }}
+      </connections>
+    </com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig>
   com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml: |-
     <?xml version='1.1' encoding='UTF-8'?>
     <com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration plugin="cloudbees-bitbucket-branch-source@2.2.10">
@@ -203,6 +224,8 @@ data:
     ln -s /var/jenkins_config/com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml /var/jenkins_home/com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml
     rm -rf /var/jenkins_home/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml
     ln -s /var/jenkins_config/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml /var/jenkins_home/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml
+    rm -rf /var/jenkins_home/com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig.xml
+    ln -s /var/jenkins_config/com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig.xml /var/jenkins_home/com.dabsquared.gitlabjenkins.connection.GitLabConnectionConfig.xml
     rm -rf /var/jenkins_home/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml
     ln -s /var/jenkins_config/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml /var/jenkins_home/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml
 {{- if .Values.Master.ScriptApproval }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -13,10 +13,16 @@ data:
       <numExecutors>0</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>{{ .Values.Master.UseSecurity }}</useSecurity>
-      <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">
-        <denyAnonymousReadAccess>true</denyAnonymousReadAccess>
+      <authorizationStrategy class="{{ .Values.Master.AuthorizationStrategyClass }}">
+        {{- range $attribute := .Values.Master.AuthorizationStrategyAttributes }}
+          <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>
+        {{- end}}
       </authorizationStrategy>
-      <securityRealm class="hudson.security.LegacySecurityRealm"/>
+      <securityRealm class="{{ .Values.Master.SecurityRealmClass }}">
+        {{- range $attribute := .Values.Master.SecurityRealmAttributes }}
+          <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>
+        {{- end}}
+      </securityRealm>
       <disableRememberMe>false</disableRememberMe>
       <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
       <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -126,6 +126,18 @@ data:
       <globalNodeProperties/>
       <noUsageStatistics>true</noUsageStatistics>
     </hudson>
+  org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <org.jenkinsci.plugins.github__branch__source.GitHubConfiguration plugin="github-branch-source@2.3.2">
+      <endpoints>
+{{- range $pkey, $pval := .Values.Servers.GHE }}
+        <org.jenkinsci.plugins.github__branch__source.Endpoint>
+          <name>{{ $pval.Name }}</name>
+          <apiUri>{{ $pval.Url }}</apiUri>
+        </org.jenkinsci.plugins.github__branch__source.Endpoint>
+{{- end }}
+      </endpoints>
+    </org.jenkinsci.plugins.github__branch__source.GitHubConfiguration>
   org.jenkinsci.plugin.gitea.servers.GiteaServers.xml: |-
     <?xml version='1.1' encoding='UTF-8'?>
     <org.jenkinsci.plugin.gitea.servers.GiteaServers plugin="gitea@1.0.5">
@@ -168,6 +180,7 @@ data:
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
     cp -n /var/jenkins_config/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml /var/jenkins_home;
+    cp -n /var/jenkins_config/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml /var/jenkins_home;
 {{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -123,7 +123,23 @@ data:
       <slaveAgentPort>50000</slaveAgentPort>
       <label></label>
       <nodeProperties/>
-      <globalNodeProperties/>
+      <globalNodeProperties>
+        <hudson.slaves.EnvironmentVariablesNodeProperty>
+          <envVars serialization="custom">
+            <unserializable-parents/>
+            <tree-map>
+              <default>
+                <comparator class="hudson.util.CaseInsensitiveComparator"/>
+              </default>
+              <int>1</int>
+{{- range $ekey, $eval := .Values.Global.EnvVars }}
+              <string>{{ $ekey }}</string>
+              <string>{{ $eval }}</string>
+{{- end }}
+            </tree-map>
+          </envVars>
+        </hudson.slaves.EnvironmentVariablesNodeProperty>
+      </globalNodeProperties>
       <noUsageStatistics>true</noUsageStatistics>
     </hudson>
   org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml: |-

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -138,6 +138,28 @@ data:
 {{- end }}
       </endpoints>
     </org.jenkinsci.plugins.github__branch__source.GitHubConfiguration>
+  com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml: |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration plugin="cloudbees-bitbucket-branch-source@2.2.10">
+      <endpoints>
+{{- range $pkey, $pval := .Values.Servers.BitbucketCloud }}
+        <com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint>
+          <manageHooks>true</manageHooks>
+          <credentialsId>{{ $pval.Credential }}</credentialsId>
+          <displayName>{{ $pval.Name }}</displayName>
+          <serverUrl>{{ $pval.Url }}</serverUrl>
+        </com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint>
+{{- end }}
+{{- range $pkey, $pval := .Values.Servers.BitbucketServer }}
+        <com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint>
+          <manageHooks>true</manageHooks>
+          <credentialsId>{{ $pval.Credential }}</credentialsId>
+          <displayName>{{ $pval.Name }}</displayName>
+          <serverUrl>{{ $pval.Url }}</serverUrl>
+        </com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint>
+{{- end }}
+      </endpoints>
+    </com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration>
   org.jenkinsci.plugin.gitea.servers.GiteaServers.xml: |-
     <?xml version='1.1' encoding='UTF-8'?>
     <org.jenkinsci.plugin.gitea.servers.GiteaServers plugin="gitea@1.0.5">
@@ -170,17 +192,19 @@ data:
     </scriptApproval>
 {{- end }}
   apply_config.sh: |-
-{{- if .Values.Master.Overwrite.Config }}
-    rm -rf /var/jenkins_home/config.xml
-{{- end }}
 {{- if .Values.Master.Overwrite.Plugins }}
     rm -rf /var/jenkins_home/plugins
 {{- end }}
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
-    cp -n /var/jenkins_config/config.xml /var/jenkins_home;
-    cp -n /var/jenkins_config/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml /var/jenkins_home;
-    cp -n /var/jenkins_config/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml /var/jenkins_home;
+    rm -rf /var/jenkins_home/config.xml
+    ln -s /var/jenkins_config/config.xml /var/jenkins_home/config.xml
+    rm -rf /var/jenkins_home/com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml
+    ln -s /var/jenkins_config/com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml /var/jenkins_home/com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration.xml
+    rm -rf /var/jenkins_home/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml
+    ln -s /var/jenkins_config/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml /var/jenkins_home/org.jenkinsci.plugin.gitea.servers.GiteaServers.xml
+    rm -rf /var/jenkins_home/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml
+    ln -s /var/jenkins_config/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml /var/jenkins_home/org.jenkinsci.plugins.github_branch_source.GitHubConfiguration.xml
 {{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -48,6 +48,12 @@ data:
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
               <volumes>
+{{- if .Values.Agent.DockerHostPath }}
+                <org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume>
+                  <hostPath>{{ ..Values.Agent.DockerHostPath }}</hostPath>
+                  <mountPath>{ ..Values.Agent.DockerMountPath }}</mountPath>
+                </org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume>
+{{- end }}
 {{- range $index, $volume := $pval.volumes }}
                 <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
 {{- range $key, $value := $volume }}{{- if not (eq $key "type") }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -29,6 +29,7 @@ data:
         <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.11">
           <name>kubernetes</name>
           <templates>
+{{- $agent := .Values.Agent -}}
 {{- if .Values.Agent.Enabled }}
 {{- range $pkey, $pval := .Values.Agent.PodTemplates }}
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
@@ -48,10 +49,10 @@ data:
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
               <volumes>
-{{- if .Values.Agent.DockerHostPath }}
+{{- if $agent.DockerSocket }}
                 <org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume>
-                  <hostPath>{{ ..Values.Agent.DockerHostPath }}</hostPath>
-                  <mountPath>{ ..Values.Agent.DockerMountPath }}</mountPath>
+                  <hostPath>{{ $agent.DockerHostPath }}</hostPath>
+                  <mountPath>{{ $agent.DockerMountPath }}</mountPath>
                 </org.csanchez.jenkins.plugins.kubernetes.volumes.HostPathVolume>
 {{- end }}
 {{- range $index, $volume := $pval.volumes }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -24,6 +24,7 @@ data:
       <securityRealm class="{{ .Values.Master.SecurityRealmClass }}">
         {{- range $attribute := .Values.Master.SecurityRealmAttributes }}
           <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>
+        {{- end}}
       </securityRealm>
 {{- else }}
       <securityRealm class="hudson.security.LegacySecurityRealm"/>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -19,7 +19,12 @@ data:
         {{- end}}
       </authorizationStrategy>
 {{- if .Values.Master.SecurityRealm }}
-{{ .Values.Master.SecurityRealm | indent 6 }}
+    {{ .Values.Master.SecurityRealm | indent 6 }}
+{{- else if  .Values.Master.SecurityRealmClass }}
+      <securityRealm class="{{ .Values.Master.SecurityRealmClass }}">
+        {{- range $attribute := .Values.Master.SecurityRealmAttributes }}
+          <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>
+      </securityRealm>
 {{- else }}
       <securityRealm class="hudson.security.LegacySecurityRealm"/>
 {{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -90,6 +90,18 @@ data:
                   <resourceRequestMemory>{{ $cval.RequestMemory }}</resourceRequestMemory>
                   <resourceLimitCpu>{{ $cval.LimitCpu }}</resourceLimitCpu>
                   <resourceLimitMemory>{{ $cval.LimitMemory }}</resourceLimitMemory>
+  {{- if and (eq $ckey "Jnlp") $agent.JnlpUnsetHttpProxyEnvVars }}
+                  <envVars>
+                    <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                      <key>http_proxy</key>
+                      <value></value>
+                    </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                    <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                      <key>https_proxy</key>
+                      <value></value>
+                    </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                  </envVars>
+  {{- end }}
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
 {{- end }}
               </containers>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -18,11 +18,11 @@ data:
           <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>
         {{- end}}
       </authorizationStrategy>
-      <securityRealm class="{{ .Values.Master.SecurityRealmClass }}">
-        {{- range $attribute := .Values.Master.SecurityRealmAttributes }}
-          <{{- $attribute.name }}>{{- $attribute.value }}</{{- $attribute.name }}>
-        {{- end}}
-      </securityRealm>
+{{- if .Values.Master.SecurityRealm }}
+{{ .Values.Master.SecurityRealm | indent 6 }}
+{{- else }}
+      <securityRealm class="hudson.security.LegacySecurityRealm"/>
+{{- end }}
       <disableRememberMe>false</disableRememberMe>
       <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
       <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
@@ -275,6 +275,11 @@ data:
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
 {{- end }}
+{{- if .Values.Master.AdditionalConfig }}
+{{- range $key, $val := .Values.Master.AdditionalConfig }}
+    cp /var/jenkins_config/{{- $key }} /var/jenkins_home;
+{{- end }}
+{{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}
   init{{ $key }}.groovy: |-
 {{ $val | indent 4 }}
@@ -284,5 +289,8 @@ data:
 {{- range $index, $val := .Values.Master.InstallPlugins }}
 {{ $val | indent 4 }}
 {{- end }}
+{{- end }}
+{{- if .Values.Master.AdditionalConfig }}
+{{- toYaml .Values.Master.AdditionalConfig | indent 2 }}
 {{- end }}
 {{- end -}}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -49,9 +49,6 @@ spec:
               mountPath: /var/jenkins_config
               name: jenkins-config
             -
-              mountPath: /usr/share/jenkins/ref/plugins/
-              name: plugin-dir
-            -
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
       containers:
@@ -103,10 +100,6 @@ spec:
               mountPath: /var/jenkins_config
               name: jenkins-config
               readOnly: true
-            -
-              mountPath: /usr/share/jenkins/ref/plugins/
-              name: plugin-dir
-              readOnly: false
             -
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -58,6 +58,19 @@ spec:
           {{- if .Values.Master.UseSecurity }}
           args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
           {{- end }}
+          readinessProbe:
+            timeoutSeconds: {{ default 5 .Values.Master.Readiness.TimeoutSeconds }}
+            initialDelaySeconds: {{ default 10 .Values.Master.Readiness.InitialDelaySeconds }}
+            httpGet:
+              path: "/login"
+              port: {{ .Values.Master.ContainerPort }}
+          livenessProbe:
+            timeoutSeconds: {{ default 5 .Values.Master.Liveness.TimeoutSeconds }}
+            initialDelaySeconds: {{ default 60 .Values.Master.Liveness.InitialDelaySeconds }}
+            failureThreshold: {{ default 10 .Values.Master.Liveness.FailureThreshold }}
+            httpGet:
+              path: "/login"
+              port: {{ .Values.Master.ContainerPort }}
           env:
             - name: JAVA_OPTS
               value: "{{ default "" .Values.Master.JavaOpts}}"

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -43,11 +43,6 @@ spec:
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
           {{- if .Values.Master.InitContainerEnv }}
           env:
-            - name: DOCKER_REGISTRY
-              valueFrom:
-                configMapKeyRef:
-                  name: jenkins-x-docker-registry
-                  key: docker.registry
 {{ toYaml .Values.Master.InitContainerEnv | indent 12 }}
           {{- end }}
           volumeMounts:
@@ -81,6 +76,11 @@ spec:
               path: "/login"
               port: {{ .Values.Master.ContainerPort }}
           env:
+            - name: DOCKER_REGISTRY
+              valueFrom:
+                configMapKeyRef:
+                  name: jenkins-x-docker-registry
+                  key: docker.registry
             - name: JAVA_OPTS
               value: "{{ default "" .Values.Master.JavaOpts}}"
             - name: JENKINS_OPTS

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -43,6 +43,11 @@ spec:
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
           {{- if .Values.Master.InitContainerEnv }}
           env:
+            - name: DOCKER_REGISTRY
+              valueFrom:
+                configMapKeyRef:
+                  name: jenkins-x-docker-registry
+                  key: docker.registry
 {{ toYaml .Values.Master.InitContainerEnv | indent 12 }}
           {{- end }}
           volumeMounts:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -41,6 +41,10 @@ spec:
           image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
           imagePullPolicy: "{{ .Values.Master.ImagePullPolicy }}"
           command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
+          {{- if .Values.Master.InitContainerEnv }}
+          env:
+{{ toYaml .Values.Master.InitContainerEnv | indent 12 }}
+          {{- end }}
           volumeMounts:
             -
               mountPath: /var/jenkins_home
@@ -87,6 +91,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "jenkins.fullname" . }}
                   key: jenkins-admin-user
+            {{- end }}
+            {{- if .Values.Master.ContainerEnv }}
+{{ toYaml .Values.Master.ContainerEnv | indent 12 }}
             {{- end }}
           ports:
             - containerPort: {{ .Values.Master.ContainerPort }}

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
+    {{- if .Values.Master.ServiceLabels }}
+{{ toYaml .Values.Master.ServiceLabels | indent 4 }}
+    {{- end }}
 {{- if .Values.Master.ServiceAnnotations }}
   annotations:
 {{ toYaml .Values.Master.ServiceAnnotations | indent 4 }}

--- a/stable/jenkins/templates/jenkins-x-git-kinds-cm.yaml
+++ b/stable/jenkins/templates/jenkins-x-git-kinds-cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "jenkins-x-git-kinds"
+data:
+  githubEnterprise: |-
+{{- range $pkey, $pval := .Values.Servers.GHE }}
+    {{ $pval.Name }}: "{{ $pval.Url }}"
+{{- end }}
+  gitea: |-
+{{- range $pkey, $pval := .Values.Servers.Gitea }}
+    {{ $pval.Name }}: "{{ $pval.Url }}"
+{{- end }}

--- a/stable/jenkins/templates/jenkins-x-git-kinds-cm.yaml
+++ b/stable/jenkins/templates/jenkins-x-git-kinds-cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: "jenkins-x-git-kinds"
 data:
-  githubEnterprise: |-
+  github: |-
 {{- range $pkey, $pval := .Values.Servers.GHE }}
     {{ $pval.Name }}: "{{ $pval.Url }}"
 {{- end }}

--- a/stable/jenkins/templates/rbac.yaml
+++ b/stable/jenkins/templates/rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $serviceName }}-role-binding
+  name: {{ $serviceName }}-{{ .Release.Namespace }}-role-binding
   labels:
     app: {{ $serviceName }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/jenkins/templates/service-account.yaml
+++ b/stable/jenkins/templates/service-account.yaml
@@ -3,6 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.Master.ServiceAccountAnnotations }}
+  annotations:
+{{ .Values.Master.ServiceAccountAnnotations | indent 4 }}
+{{- end }}
   name: {{ $serviceName }}
   labels:
     app: {{ $serviceName }}

--- a/stable/jenkins/templates/test-config.yaml
+++ b/stable/jenkins/templates/test-config.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing Jenkins UI is accessible" {
-      curl --retry 12 --retry-delay 10 {{ .Release.Name }}-jenkins:8080{{ default "" .Values.Master.JenkinsUriPrefix }}/login
+      curl --retry 12 --retry-delay 10 jenkins:8080{{ default "" .Values.Master.JenkinsUriPrefix }}/login
     }

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -102,6 +102,10 @@ Agent:
   DockerMountPath: "/var/run/docker.sock"
 
   KubernetesServerURL: "https://kubernetes.default"
+  
+  #Set to true when http proxy env variables are set (in Docker engine/Jenkins global configuration/template pods) to add empty "http_proxy" and "https_proxy" in the Jnlp containers.
+  #Required for connectivity between Jnlp agent and Jenkins master containers on cluster that uses http/https proxy, as the Jnlp does not respect the no_proxy env variable.
+  JnlpSetEmptyHttpProxyEnvVars: false
 
   # Key Value selectors. Ex:
   # jenkins-agent: v1

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -115,6 +115,11 @@ Agent:
       #   mountPath: /var/myapp/mysecret
       NodeSelector: {}
 
+Servers:
+  Gitea:
+  - Name: gitea
+    Url: http://gitea.changeme.com
+    Credential: jenkins-x-gitea
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -115,7 +115,7 @@ Agent:
       #   mountPath: /var/myapp/mysecret
       NodeSelector: {}
 
-Servers:
+Servers:  
   Gitea:
   - Name: gitea
     Url: http://gitea.changeme.com

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -77,7 +77,7 @@ Master:
 
 Agent:
   Enabled: true
-  
+  ContainerCap: 10
   Component: "jenkins-agent"
 
   # Key Value selectors. Ex:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -71,6 +71,9 @@ Master:
       # - secretName: jenkins.cluster.local
       #   hosts:
       #     - jenkins.cluster.local
+  Overwrite: {}
+    # Plugins: true
+    # Config: true
 
 Agent:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -41,13 +41,6 @@ Master:
 #   -Dcom.sun.management.jmxremote.authenticate=false
 #   -Dcom.sun.management.jmxremote.ssl=false
 # JMXPort: 4000
-# List of plugins to be install during Jenkins master start
-  InstallPlugins:
-    - kubernetes:0.11
-    - workflow-aggregator:2.5
-    - workflow-job:2.13
-    - credentials-binding:1.12
-    - git:3.4.0
 # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   # ScriptApproval:
   #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -55,7 +55,13 @@ Master:
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
   NodeSelector: {}
   Tolerations: {}
-
+  Readiness:
+    TimeoutSeconds:
+    InitialDelaySeconds:
+  Liveness:
+    TimeoutSeconds:
+    InitialDelaySeconds:
+    FailureThreshold:
   Ingress:
     Annotations:
       # kubernetes.io/ingress.class: nginx
@@ -68,25 +74,44 @@ Master:
 
 Agent:
   Enabled: true
-  Image: jenkinsci/jnlp-slave
-  ImageTag: 2.62
-  Component: "jenkins-slave"
-  Privileged: false
-  Cpu: "200m"
-  Memory: "256Mi"
-  # You may want to change this to true while testing a new image
-  AlwaysPullImage: false
-  # You can define the volumes that you want to mount for this container
-  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
-  # Configure the attributes as they appear in the corresponding Java class for that type
-  # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
-  volumes:
-  # - type: Secret
-  #   secretName: mysecret
-  #   mountPath: /var/myapp/mysecret
-  NodeSelector: {}
+  
+  Component: "jenkins-agent"
+
   # Key Value selectors. Ex:
   # jenkins-agent: v1
+  PodTemplates:
+    Maven:
+      Name: default
+      Label: jenkins-maven
+      EnvVars:
+        JENKINS_URL: http://jenkins:8080
+      Containers:
+        Jnlp:
+          Image: jenkinsci/jnlp-slave:2.62
+          RequestCpu: "100m"
+          RequestMemory: "128Mi"
+        # Maven:
+        #   Image: fabric8/maven-builder:vd81dedb
+        #   Privileged: true
+        #   RequestCpu: "200m"
+        #   RequestMemory: "256Mi"
+        #   LimitCpu: "200m"
+        #   LimitMemory: "256Mi"
+
+          # You may want to change this to true while testing a new image
+          # AlwaysPullImage: true
+          # Command:
+
+      # You can define the volumes that you want to mount for this container
+      # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
+      # Configure the attributes as they appear in the corresponding Java class for that type
+      # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
+      volumes:
+      # - type: Secret
+      #   secretName: mysecret
+      #   mountPath: /var/myapp/mysecret
+      NodeSelector: {}
+
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -82,11 +82,6 @@ Master:
     # Plugins: true
     # Config: true
 
-# global node properties
-Global:
-  EnvVars:
-    DOCKER_REGISTRY: ""
-
 Agent:
   Enabled: true
   ContainerCap: 10
@@ -157,6 +152,14 @@ Servers:
   #- Name: myname
   #  Url: https://something.com/
   #  Credential: some-cred-name
+
+  # global node properties
+  Global:
+    NumEnvVars: 2
+    EnvVars:
+      DOCKER_REGISTRY: ""
+      TILLER_NAMESPACE: ""
+
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -95,6 +95,8 @@ Agent:
   DockerHostPath: "/var/run/docker.sock"
   DockerMountPath: "/var/run/docker.sock"
 
+  KubernetesServerURL: "https://kubernetes.default"
+
   # Key Value selectors. Ex:
   # jenkins-agent: v1
   PodTemplates:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -92,7 +92,6 @@ Agent:
   ContainerCap: 10
   Component: "jenkins-agent"
 
-  DockerSocket: true
   DockerHostPath: "/var/run/docker.sock"
   DockerMountPath: "/var/run/docker.sock"
 

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -136,6 +136,11 @@ Servers:
   #  Url: https://something.com/
   #  Credential: some-cred-name
 
+  GitLab:
+  #- Name: myname
+  #  Url: https://something.com/
+  #  Credential: some-cred-name
+
 Persistence:
   Enabled: true
   ## A manually managed Persistent Volume and Claim

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -18,6 +18,13 @@ Master:
 # JavaOpts: "-Xms512m -Xmx512m"
 # JenkinsOpts: ""
 # JenkinsUriPrefix: "/jenkins"
+# Environment variables that get added to the init container (useful for e.g. http_proxy)
+# InitContainerEnv:
+#   - name: http_proxy
+#     value: "http://192.168.64.1:3128"
+# ContainerEnv:
+#   - name: http_proxy
+#     value: "http://192.168.64.1:3128"
   ServicePort: 8080
 # For minikube, set this to NodePort, elsewhere use LoadBalancer
 # Use ClusterIP if your setup includes ingress controller

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -12,6 +12,13 @@ Master:
   UseSecurity: true
   AdminUser: admin
 # AdminPassword: <defaults to random>
+  AuthorizationStrategyClass: "hudson.security.FullControlOnceLoggedInAuthorizationStrategy"
+  AuthorizationStrategyAttributes:
+    - name: 'denyAnonymousReadAccess'
+      value: 'true'
+  SecurityRealmClass: "hudson.security.LegacySecurityRealm"
+  SecurityRealmAttributes: {}
+  ServiceAccountAnnotations: {}
   Cpu: "200m"
   Memory: "256Mi"
 # Set min/max heap here if needed with:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -92,6 +92,10 @@ Agent:
   ContainerCap: 10
   Component: "jenkins-agent"
 
+  DockerSocket: true
+  DockerHostPath: "/var/run/docker.sock"
+  DockerMountPath: "/var/run/docker.sock"
+
   # Key Value selectors. Ex:
   # jenkins-agent: v1
   PodTemplates:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -116,10 +116,14 @@ Agent:
       NodeSelector: {}
 
 Servers:  
-  Gitea:
-  - Name: gitea
-    Url: http://gitea.changeme.com
-    Credential: jenkins-x-gitea
+  #Gitea:
+  #- Name: gitea
+  #  Url: http://gitea.changeme.com
+  #  Credential: jenkins-x-gitea
+  #
+  # GHE
+  # BitbucketCloud
+  # BitbucketServer
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -116,14 +116,25 @@ Agent:
       NodeSelector: {}
 
 Servers:  
-  #Gitea:
-  #- Name: gitea
-  #  Url: http://gitea.changeme.com
-  #  Credential: jenkins-x-gitea
-  #
-  # GHE
-  # BitbucketCloud
-  # BitbucketServer
+  Gitea:
+  #- Name: myname
+  #  Url: https://something.com/
+  #  Credential: some-cred-name
+
+  GHE:
+  #- Name: myname
+  #  Url: https://something.com/
+  #  Credential: some-cred-name
+
+  BitbucketCloud:
+  #- Name: myname
+  #  Url: https://something.com/
+  #  Credential: some-cred-name
+
+  BitbucketServer:
+  #- Name: myname
+  #  Url: https://something.com/
+  #  Credential: some-cred-name
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -82,6 +82,11 @@ Master:
     # Plugins: true
     # Config: true
 
+# global node properties
+Global:
+  EnvVars:
+    DOCKER_REGISTRY: ""
+
 Agent:
   Enabled: true
   ContainerCap: 10

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -10,6 +10,7 @@ Master:
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   UseSecurity: true
+  #SecurityRealm
   AdminUser: admin
 # AdminPassword: <defaults to random>
   AuthorizationStrategyClass: "hudson.security.FullControlOnceLoggedInAuthorizationStrategy"
@@ -19,6 +20,8 @@ Master:
   SecurityRealmClass: "hudson.security.LegacySecurityRealm"
   SecurityRealmAttributes: {}
   ServiceAccountAnnotations: {}
+  # Master Service Labels
+  ServiceLabels: {}
   Cpu: "200m"
   Memory: "256Mi"
 # Set min/max heap here if needed with:
@@ -88,6 +91,7 @@ Master:
   Overwrite: {}
     # Plugins: true
     # Config: true
+  AdditionalConfig: {}
 
 Agent:
   Enabled: true
@@ -134,7 +138,7 @@ Agent:
       #   mountPath: /var/myapp/mysecret
       NodeSelector: {}
 
-Servers:  
+Servers:
   Gitea:
   #- Name: myname
   #  Url: https://something.com/


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds option to unset the http_proxy and https_proxy environment variables for Jnlp containers.
Required for connectivity between Jnlp agent and Jenkins master containers on cluster that uses http/https proxy, as the Jnlp does not respect the no_proxy env variable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes https://github.com/jenkins-x/jx/issues/3328

**Special notes for your reviewer**:
After a relevant discussion with @jstrachan on slack, added flag into the "values.yaml" in the platform chart to add the necessary env vars for http proxy setup of Jnlp containers.