### PR TITLE
Unset http proxy variables for Jnlp containers

### DIFF
--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -90,7 +90,7 @@ data:
                   <resourceRequestMemory>{{ $cval.RequestMemory }}</resourceRequestMemory>
                   <resourceLimitCpu>{{ $cval.LimitCpu }}</resourceLimitCpu>
                   <resourceLimitMemory>{{ $cval.LimitMemory }}</resourceLimitMemory>
-  {{- if and (eq $ckey "Jnlp") $agent.JnlpUnsetHttpProxyEnvVars }}
+  {{- if and (eq $ckey "Jnlp") $agent.JnlpSetEmptyHttpProxyEnvVars }}
                   <envVars>
                     <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
                       <key>http_proxy</key>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -90,6 +90,18 @@ data:
                   <resourceRequestMemory>{{ $cval.RequestMemory }}</resourceRequestMemory>
                   <resourceLimitCpu>{{ $cval.LimitCpu }}</resourceLimitCpu>
                   <resourceLimitMemory>{{ $cval.LimitMemory }}</resourceLimitMemory>
+  {{- if and (eq $ckey "Jnlp") $agent.JnlpUnsetHttpProxyEnvVars }}
+                  <envVars>
+                    <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                      <key>http_proxy</key>
+                      <value></value>
+                    </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                    <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                      <key>https_proxy</key>
+                      <value></value>
+                    </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                  </envVars>
+  {{- end }}
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
 {{- end }}
               </containers>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -102,6 +102,10 @@ Agent:
   DockerMountPath: "/var/run/docker.sock"
 
   KubernetesServerURL: "https://kubernetes.default"
+  
+  #Set to true when http proxy env variables are set (in Docker engine/Jenkins global configuration/template pods) to add empty "http_proxy" and "https_proxy" in the Jnlp containers.
+  #Required for connectivity between Jnlp agent and Jenkins master containers on cluster that uses http/https proxy, as the Jnlp does not respect the no_proxy env variable.
+  JnlpSetEmptyHttpProxyEnvVars: false
 
   # Key Value selectors. Ex:
   # jenkins-agent: v1


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds option to unset the http_proxy and https_proxy environment variables for Jnlp containers.
Required for connectivity between Jnlp agent and Jenkins master containers on cluster that uses http/https proxy, as the Jnlp does not respect the no_proxy env variable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes jenkins-x/jx#3328

**Special notes for your reviewer**:
After a relevant discussion with @jstrachan on slack, added flag into the "values.yaml" in the platform chart to add the necessary env vars for http proxy setup of Jnlp containers.