### PR TITLE
Support Kubernetes 1.16 APIs

### DIFF
--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jenkins.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it:**
Change API Path defined in Deployment to support 1.16 prerequisites.
See: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/