### PR TITLE
support-kubernetes-1.16-apis

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.10.38
+version: 0.10.39
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Makefile
+++ b/stable/jenkins/Makefile
@@ -1,7 +1,7 @@
 CHART_REPO := https://chartmuseum-jx.jenkins-x.live
 NAME := jenkins
 OS := $(shell uname)
-RELEASE_VERSION := 0.10.38
+RELEASE_VERSION := 0.10.39
 
 setup:
 	minikube addons enable ingress

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jenkins.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it:**
Change API Path defined in Deployment to support 1.16 prerequisites.
See: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

**Which issue this PR fixes:**

`DaemonSet, Deployment, StatefulSet, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 by default in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved/updated via the apps/v1 API.`
